### PR TITLE
Bug "Adding catch fails" solved

### DIFF
--- a/editcatchdialog.h
+++ b/editcatchdialog.h
@@ -23,11 +23,13 @@ private slots:
     void onButtonBoxAccepted();
     void onEditLengthFinished();
     void onEditWeightFinished();
+    void onEditTimeFinished();
 
 private:
     Ui::EditCatchDialog *ui;
     CatchModel *catchModel;
     QDataWidgetMapper *mapper;
+    int findSessionId();
 };
 
 #endif // EDITCATCHDIALOG_H


### PR DESCRIPTION
Session id is set in the catch model if date/time editing is finished or catch dialog closed by ok button.